### PR TITLE
Build encrypted iMessage-style messaging app prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Orchid Messages
+
+An iMessage-inspired encrypted messaging experience with a polished Apple-style interface.
+
+## What this build includes
+
+- **End-to-end encryption demo flow** in-browser using:
+  - ECDH (`P-256`) for key agreement.
+  - AES-256-GCM for message encryption/decryption.
+- **Modern, premium UI** with blur-glass panels, gradients, and responsive layout.
+- **Conversation UX** with contacts list, bubble chat stream, and quick composer.
+- **Device identity controls** to regenerate keys and clear threads.
+
+## Run locally
+
+Because the app uses JavaScript modules, serve files over HTTP:
+
+```bash
+python3 -m http.server 4173
+```
+
+Then open:
+
+- `http://localhost:4173/index.html`
+
+## Security notes
+
+This project is a **high-fidelity prototype** for UX + cryptography mechanics, not production-ready infrastructure.
+To reach Apple-grade production standards, you would still need:
+
+- Strong identity/authentication service and key transparency.
+- Secure key backup/recovery strategy.
+- Multi-device session protocol and forward secrecy ratchets.
+- Metadata minimization, abuse controls, audits, and formal review.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,241 @@
+const identityStatus = document.querySelector('#identityStatus');
+const contactList = document.querySelector('#contactList');
+const activeContactName = document.querySelector('#activeContactName');
+const messageStream = document.querySelector('#messageStream');
+const composer = document.querySelector('#composer');
+const messageInput = document.querySelector('#messageInput');
+const clearConversation = document.querySelector('#clearConversation');
+const regenerateIdentity = document.querySelector('#regenerateIdentity');
+const messageTemplate = document.querySelector('#messageTemplate');
+
+const state = {
+  me: null,
+  activeContactId: null,
+  contacts: [
+    { id: 'lena', name: 'Lena Park', preview: 'Design review complete ✅' },
+    { id: 'miles', name: 'Miles Rivera', preview: 'Meet me at 7 near the marina.' },
+    { id: 'sora', name: 'Sora Ahmed', preview: 'Trip itinerary is ready.' },
+  ],
+  conversations: new Map(),
+};
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const toB64 = (arr) => btoa(String.fromCharCode(...new Uint8Array(arr)));
+const fromB64 = (str) => Uint8Array.from(atob(str), (c) => c.charCodeAt(0));
+
+async function createIdentity(name = 'You') {
+  const agreementKeys = await crypto.subtle.generateKey(
+    { name: 'ECDH', namedCurve: 'P-256' },
+    true,
+    ['deriveKey']
+  );
+
+  return {
+    id: crypto.randomUUID(),
+    name,
+    agreementKeys,
+  };
+}
+
+async function deriveSharedKey(privateKey, publicKey) {
+  return crypto.subtle.deriveKey(
+    { name: 'ECDH', public: publicKey },
+    privateKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+async function encryptMessage(sharedKey, plaintext) {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    sharedKey,
+    encoder.encode(plaintext)
+  );
+
+  return {
+    iv: toB64(iv),
+    ciphertext: toB64(ciphertext),
+  };
+}
+
+async function decryptMessage(sharedKey, payload) {
+  const iv = fromB64(payload.iv);
+  const ciphertext = fromB64(payload.ciphertext);
+  const plainBuffer = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    sharedKey,
+    ciphertext
+  );
+
+  return decoder.decode(plainBuffer);
+}
+
+async function ensureConversation(contactId) {
+  if (state.conversations.has(contactId)) {
+    return state.conversations.get(contactId);
+  }
+
+  const contactIdentity = await createIdentity(
+    state.contacts.find((contact) => contact.id === contactId)?.name ?? 'Contact'
+  );
+  const sharedKeyForMe = await deriveSharedKey(
+    state.me.agreementKeys.privateKey,
+    contactIdentity.agreementKeys.publicKey
+  );
+  const sharedKeyForContact = await deriveSharedKey(
+    contactIdentity.agreementKeys.privateKey,
+    state.me.agreementKeys.publicKey
+  );
+
+  const conversation = {
+    messages: [],
+    keys: {
+      me: sharedKeyForMe,
+      them: sharedKeyForContact,
+    },
+  };
+
+  state.conversations.set(contactId, conversation);
+  return conversation;
+}
+
+function renderContacts() {
+  contactList.innerHTML = '';
+
+  state.contacts.forEach((contact) => {
+    const button = document.createElement('button');
+    button.className = `contact ${contact.id === state.activeContactId ? 'active' : ''}`;
+    button.type = 'button';
+    button.innerHTML = `
+      <div class="contact-title">
+        <strong>${contact.name}</strong>
+        <span>🔒</span>
+      </div>
+      <p class="contact-snippet">${contact.preview}</p>
+    `;
+
+    button.addEventListener('click', async () => {
+      state.activeContactId = contact.id;
+      await ensureConversation(contact.id);
+      renderContacts();
+      renderMessages();
+    });
+
+    contactList.append(button);
+  });
+}
+
+async function renderMessages() {
+  const contact = state.contacts.find((entry) => entry.id === state.activeContactId);
+
+  if (!contact) {
+    activeContactName.textContent = 'Select a contact';
+    messageStream.innerHTML = '<p class="system-note">Choose a conversation to begin.</p>';
+    composer.style.visibility = 'hidden';
+    return;
+  }
+
+  activeContactName.textContent = contact.name;
+  composer.style.visibility = 'visible';
+
+  const conversation = await ensureConversation(contact.id);
+  messageStream.innerHTML = '';
+
+  if (!conversation.messages.length) {
+    messageStream.innerHTML =
+      '<p class="system-note">Messages are encrypted with AES-256-GCM using ephemeral ECDH-derived keys.</p>';
+    return;
+  }
+
+  for (const encryptedMessage of conversation.messages) {
+    const sharedKey = encryptedMessage.sender === 'me' ? conversation.keys.them : conversation.keys.me;
+    const plaintext = await decryptMessage(sharedKey, encryptedMessage.payload);
+
+    const fragment = messageTemplate.content.cloneNode(true);
+    const bubbleWrap = fragment.querySelector('.bubble-wrap');
+    const bubble = fragment.querySelector('.bubble');
+    const time = fragment.querySelector('time');
+
+    bubbleWrap.classList.add(encryptedMessage.sender === 'me' ? 'me' : 'them');
+    bubble.textContent = plaintext;
+    time.textContent = new Date(encryptedMessage.sentAt).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+    messageStream.append(fragment);
+  }
+
+  messageStream.scrollTop = messageStream.scrollHeight;
+}
+
+async function sendEncryptedMessage(rawText) {
+  const text = rawText.trim();
+  if (!text || !state.activeContactId) return;
+
+  const conversation = await ensureConversation(state.activeContactId);
+  const payloadForContact = await encryptMessage(conversation.keys.me, text);
+
+  conversation.messages.push({
+    sender: 'me',
+    payload: payloadForContact,
+    sentAt: Date.now(),
+  });
+
+  setTimeout(async () => {
+    const autoReply = `Encrypted echo: ${text}`;
+    const payloadForMe = await encryptMessage(conversation.keys.them, autoReply);
+
+    conversation.messages.push({
+      sender: 'them',
+      payload: payloadForMe,
+      sentAt: Date.now(),
+    });
+
+    if (state.activeContactId) {
+      renderMessages();
+    }
+  }, 450);
+
+  renderMessages();
+}
+
+async function bootstrap() {
+  state.me = await createIdentity();
+  identityStatus.textContent = `Device ready • ${state.me.id.slice(0, 8)}… • ECDH P-256`;
+
+  state.activeContactId = state.contacts[0].id;
+
+  renderContacts();
+  await ensureConversation(state.activeContactId);
+  await renderMessages();
+}
+
+composer.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const text = messageInput.value;
+  messageInput.value = '';
+  await sendEncryptedMessage(text);
+});
+
+clearConversation.addEventListener('click', async () => {
+  if (!state.activeContactId) return;
+  const conversation = await ensureConversation(state.activeContactId);
+  conversation.messages = [];
+  renderMessages();
+});
+
+regenerateIdentity.addEventListener('click', async () => {
+  state.me = await createIdentity();
+  state.conversations.clear();
+  identityStatus.textContent = `Identity regenerated • ${state.me.id.slice(0, 8)}…`;
+  await ensureConversation(state.activeContactId);
+  await renderMessages();
+});
+
+bootstrap();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Orchid Messages</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app-shell">
+      <aside class="sidebar">
+        <div class="brand">
+          <div class="brand-mark">✦</div>
+          <div>
+            <h1>Orchid</h1>
+            <p>Private messages, reimagined.</p>
+          </div>
+        </div>
+
+        <section class="identity-card">
+          <h2>Your device identity</h2>
+          <p id="identityStatus">Generating cryptographic identity…</p>
+          <button id="regenerateIdentity" class="ghost-btn">Regenerate keys</button>
+        </section>
+
+        <section class="contact-list" id="contactList" aria-label="Contacts"></section>
+      </aside>
+
+      <section class="chat-panel">
+        <header class="chat-header">
+          <div>
+            <h2 id="activeContactName">Select a contact</h2>
+            <p id="securityPill">🔒 End-to-end encrypted</p>
+          </div>
+          <button id="clearConversation" class="ghost-btn">Clear thread</button>
+        </header>
+
+        <div class="message-stream" id="messageStream" aria-live="polite"></div>
+
+        <form id="composer" class="composer">
+          <input
+            id="messageInput"
+            type="text"
+            placeholder="Write an encrypted message…"
+            maxlength="500"
+            autocomplete="off"
+            required
+          />
+          <button type="submit" class="send-btn">Send</button>
+        </form>
+      </section>
+    </main>
+
+    <template id="messageTemplate">
+      <article class="bubble-wrap">
+        <div class="bubble"></div>
+        <time></time>
+      </article>
+    </template>
+
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,237 @@
+:root {
+  --bg-start: #0f172a;
+  --bg-end: #111827;
+  --panel: rgba(17, 24, 39, 0.55);
+  --border: rgba(255, 255, 255, 0.12);
+  --text: #e5e7eb;
+  --muted: #94a3b8;
+  --accent: #0a84ff;
+  --bubble-me: linear-gradient(140deg, #0a84ff, #2663ff);
+  --bubble-them: rgba(148, 163, 184, 0.18);
+  --danger: #ef4444;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, -apple-system, sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top right, #1d4ed8, transparent 36%),
+    radial-gradient(circle at bottom left, #7c3aed, transparent 42%),
+    linear-gradient(160deg, var(--bg-start), var(--bg-end));
+}
+
+.app-shell {
+  width: min(1180px, 96vw);
+  margin: 2rem auto;
+  min-height: calc(100vh - 4rem);
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 1rem;
+}
+
+.sidebar,
+.chat-panel {
+  backdrop-filter: blur(24px);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+}
+
+.sidebar {
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-rows: auto auto 1fr;
+}
+
+.brand {
+  display: flex;
+  gap: 0.7rem;
+  align-items: center;
+}
+
+.brand h1,
+.chat-header h2,
+.identity-card h2 {
+  margin: 0;
+}
+
+.brand p,
+#securityPill,
+.identity-card p,
+.contact-snippet {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.brand-mark {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-size: 1.2rem;
+  background: linear-gradient(135deg, #60a5fa, #8b5cf6);
+  box-shadow: 0 10px 26px rgba(96, 165, 250, 0.3);
+}
+
+.identity-card {
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.ghost-btn,
+.send-btn {
+  border: 0;
+  border-radius: 10px;
+  padding: 0.6rem 0.9rem;
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.ghost-btn {
+  margin-top: 0.75rem;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.ghost-btn:hover {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.contact-list {
+  display: grid;
+  gap: 0.65rem;
+  align-content: start;
+}
+
+.contact {
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.35);
+  padding: 0.75rem;
+  cursor: pointer;
+  color: var(--text);
+}
+
+.contact:hover,
+.contact.active {
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(14, 165, 233, 0.15);
+}
+
+.contact-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.chat-panel {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  padding: 1rem;
+  min-height: 72vh;
+}
+
+.chat-header {
+  padding: 0.4rem 0.35rem 0.85rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.message-stream {
+  padding: 1rem 0.25rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.bubble-wrap {
+  display: grid;
+  gap: 0.25rem;
+  max-width: 76%;
+}
+
+.bubble-wrap.me {
+  align-self: end;
+  justify-items: end;
+}
+
+.bubble {
+  padding: 0.72rem 0.95rem;
+  border-radius: 18px;
+  line-height: 1.45;
+}
+
+.bubble-wrap.me .bubble {
+  background: var(--bubble-me);
+  border-bottom-right-radius: 6px;
+}
+
+.bubble-wrap.them .bubble {
+  background: var(--bubble-them);
+  border-bottom-left-radius: 6px;
+}
+
+.bubble-wrap time {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.composer {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.6rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  padding-top: 0.9rem;
+}
+
+#messageInput {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+}
+
+#messageInput:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.6);
+  border-color: transparent;
+}
+
+.send-btn {
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  min-width: 90px;
+}
+
+.system-note {
+  margin: auto;
+  color: var(--muted);
+  text-align: center;
+}
+
+@media (max-width: 980px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    margin: 0.75rem;
+    width: auto;
+  }
+
+  .chat-panel {
+    min-height: 64vh;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a high-fidelity, client-side prototype of an iMessage-inspired messaging app that demonstrates end-to-end encryption primitives and a polished Apple-style UI.
- Ship a self-contained demo that exercises cryptographic key agreement and message encryption flows while keeping a clear distinction that this is a prototype and not production-ready.

### Description
- Add a single-page UI in `index.html` implementing a contact sidebar, identity controls, message stream, and composer for a chat-like experience.
- Add `styles.css` to provide a premium Apple-like visual system (glass blur panels, gradients, responsive layout, and chat bubbles).
- Implement client-side encryption logic in `app.js` using ECDH (`P-256`) for key agreement and AES-256-GCM for message encryption/decryption, plus conversation management (send, simulated encrypted reply, clear thread, regenerate identity).
- Add `README.md` documenting how to run the demo locally and outlining security limitations and production requirements.

### Testing
- Ran a static syntax check with `node --check app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacd27b4308328bbc724399790a6bf)